### PR TITLE
feat(ci): add Modal preview deployment for PRs

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,53 @@
+name: Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Delete preview environment
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+          ENV_NAME="pr-${PR_NUM}"
+
+          echo "Cleaning up Modal environment: ${ENV_NAME}"
+          modal environment delete "$ENV_NAME" --confirm 2>/dev/null || echo "Environment already deleted or not found"
+
+      - name: Update PR comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNum = ${{ github.event.pull_request.number }};
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNum,
+            });
+
+            const botComment = comments.data.find(c =>
+              c.body.includes('🚀 Preview Deployed')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: `## 🚀 Preview Deployed\n\n⚪ **Preview torn down** — PR was ${context.payload.pull_request.merged ? 'merged' : 'closed'}.`,
+              });
+            }

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,91 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Deploy preview to Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+          ENV_NAME="pr-${PR_NUM}"
+
+          # Create environment if it doesn't exist (ignore error if exists)
+          modal environment create "$ENV_NAME" 2>/dev/null || true
+
+          # Deploy the preview app
+          modal deploy deploy/preview_app.py --env "$ENV_NAME"
+
+          echo "PREVIEW_ENV=${ENV_NAME}" >> $GITHUB_ENV
+          echo "PR_NUM=${PR_NUM}" >> $GITHUB_ENV
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNum = ${{ github.event.pull_request.number }};
+            const envName = `pr-${prNum}`;
+            const previewUrl = `https://${context.repo.owner}--rt-preview-web.modal.run`;
+            const sha = context.sha.substring(0, 7);
+
+            const body = [
+              `## 🚀 Preview Deployed`,
+              ``,
+              `| | |`,
+              `|---|---|`,
+              `| **URL** | [${previewUrl}](${previewUrl}) |`,
+              `| **Environment** | \`${envName}\` |`,
+              `| **Commit** | \`${sha}\` |`,
+              `| **API Docs** | [${previewUrl}/api/docs](${previewUrl}/api/docs) |`,
+              ``,
+              `> Preview auto-sleeps after 5 min idle. First request may take ~10s cold start.`,
+            ].join('\n');
+
+            // Find existing comment
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNum,
+            });
+
+            const botComment = comments.data.find(c =>
+              c.body.includes('🚀 Preview Deployed')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNum,
+                body,
+              });
+            }

--- a/.modalignore
+++ b/.modalignore
@@ -1,0 +1,11 @@
+node_modules/
+.git/
+__pycache__/
+dist/
+.worktrees/
+.venv/
+.env
+.DS_Store
+*.pyc
+.mypy_cache/
+.pytest_cache/

--- a/deploy/preview_app.py
+++ b/deploy/preview_app.py
@@ -1,0 +1,96 @@
+"""Modal preview app — serves frontend + backend for PR previews.
+
+Each PR gets its own Modal environment (pr-{number}), serving:
+- Static frontend (Vite build) at /
+- FastAPI backend at /api/*
+
+Usage:
+  modal deploy deploy/preview_app.py --env pr-42
+  modal serve deploy/preview_app.py  # local dev
+"""
+
+import modal
+import os
+
+# ── Modal image: Node 20 for frontend build + Python 3.11 for backend ──
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .apt_install("curl")
+    .run_commands(
+        # Install Node.js 20
+        "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
+        "apt-get install -y nodejs",
+    )
+    .pip_install("fastapi[standard]", "uvicorn", "pydantic", "pydantic-settings")
+    # Copy the full repo into the image
+    .add_local_dir(".", "/app", condition=lambda path: (
+        not any(ignore in path for ignore in [
+            "node_modules", ".git", "__pycache__", "dist", ".worktrees",
+            ".venv", ".env", ".DS_Store",
+        ])
+    ))
+    # Build frontend inside the image
+    .run_commands(
+        "cd /app/frontend && npm install --prefer-offline --no-audit && npm run build",
+    )
+)
+
+app = modal.App("rt-preview")
+
+
+@app.function(
+    image=image,
+    allow_concurrent_inputs=100,
+    container_idle_timeout=300,  # 5 min idle before sleep
+)
+@modal.asgi_app()
+def web():
+    """Serve the full-stack app: frontend static files + backend API."""
+    import sys
+    sys.path.insert(0, "/app/backend")
+
+    from fastapi import FastAPI
+    from fastapi.staticfiles import StaticFiles
+    from fastapi.responses import FileResponse
+
+    # Import backend routers
+    from api.tasks import router as tasks_router
+    from api.chat import router as chat_router
+    from api.extensions import router as extensions_router
+
+    preview_app = FastAPI(
+        title="Research Toolbox Preview",
+        docs_url="/api/docs",
+        openapi_url="/api/openapi.json",
+    )
+
+    # ── Health check ──
+    @preview_app.get("/api/health")
+    def health():
+        env = os.environ.get("MODAL_ENVIRONMENT", "unknown")
+        return {"status": "ok", "environment": env, "preview": True}
+
+    # ── Backend API routes ──
+    preview_app.include_router(tasks_router, prefix="/api")
+    preview_app.include_router(chat_router, prefix="/api")
+    preview_app.include_router(extensions_router, prefix="/api")
+
+    # ── Frontend static files ──
+    # Serve index.html for all non-API routes (SPA routing)
+    @preview_app.get("/{path:path}")
+    async def serve_spa(path: str):
+        import pathlib
+        static_dir = pathlib.Path("/app/frontend/dist")
+        file_path = static_dir / path
+        if file_path.is_file():
+            return FileResponse(file_path)
+        return FileResponse(static_dir / "index.html")
+
+    # Mount static assets
+    preview_app.mount(
+        "/assets",
+        StaticFiles(directory="/app/frontend/dist/assets"),
+        name="assets",
+    )
+
+    return preview_app

--- a/deploy/preview_app.py
+++ b/deploy/preview_app.py
@@ -22,13 +22,8 @@ image = (
         "apt-get install -y nodejs",
     )
     .pip_install("fastapi[standard]", "uvicorn", "pydantic", "pydantic-settings")
-    # Copy the full repo into the image
-    .add_local_dir(".", "/app", condition=lambda path: (
-        not any(ignore in path for ignore in [
-            "node_modules", ".git", "__pycache__", "dist", ".worktrees",
-            ".venv", ".env", ".DS_Store",
-        ])
-    ))
+    # Copy the repo into the image (filtered by .modalignore)
+    .add_local_dir(".", "/app")
     # Build frontend inside the image
     .run_commands(
         "cd /app/frontend && npm install --prefer-offline --no-audit && npm run build",

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,0 +1,6 @@
+# Deploy dependencies
+modal
+fastapi[standard]
+uvicorn
+pydantic
+pydantic-settings


### PR DESCRIPTION
## Summary

Adds live PR preview environments via Modal. Each PR gets its own isolated deployment with frontend + backend on a single URL.

## How It Works

1. **On PR open/sync**: `preview-deploy.yml` triggers
   - Creates Modal environment `pr-{N}`
   - Deploys `deploy/preview_app.py` — builds Vite frontend in-container, serves it alongside FastAPI backend
   - Posts a comment on the PR with the preview URL

2. **On PR close**: `preview-cleanup.yml` triggers
   - Deletes the Modal environment
   - Updates the PR comment to show teardown

## Preview App Architecture
- Single ASGI endpoint via `@modal.asgi_app()`
- Frontend: Vite build output served as static files at `/`
- Backend: FastAPI routes at `/api/*`
- Auto-sleeps after 5 min idle (serverless)

## Files
| File | Purpose |
|------|---------|
| `deploy/preview_app.py` | Modal app serving frontend + backend |
| `deploy/requirements.txt` | Python deps for deploy |
| `.github/workflows/preview-deploy.yml` | Deploy workflow |
| `.github/workflows/preview-cleanup.yml` | Cleanup workflow |

## Required Secrets
- `MODAL_TOKEN_ID` — from `modal token new`
- `MODAL_TOKEN_SECRET` — from `modal token new`